### PR TITLE
Tests to instal requirements.txt

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -28,7 +28,7 @@ jobs:
           wget https://github.com/inkle/ink/releases/download/v.1.2.0/inklecate_linux.zip
       # Unzip the file for later use
       - name: Unzip inklecate
-        run: unzip -o inklecate_linux.zip
+        run: unzip -o inklecate_linux.zip -d inklecate/
       # Compile the story into story.ink.json
       - name: Compile story
         run: ./inklecate story.ink

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           wget https://github.com/inkle/ink/releases/download/v.1.2.0/inklecate_linux.zip
       - name: Unzip inklecate
-        run: unzip -o inklecate_linux.zip inklecate/
+        run: unzip -o inklecate_linux.zip -d inklecate/
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,22 +20,20 @@ jobs:
         uses: actions/cache@v3
         with:
           path: inklecate_linux.zip
-          key: inklecate-${{ hashFiles('inklecate_version.txt') }}
+          key: inklecate-v1.2.0
           restore-keys: |
-            inklecate-
+            inklecate-v1.2.0
       # Download the release if not found in cache
       - name: Download inklecate
         if: steps.inklecate-cache.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/inkle/ink/releases/download/v.1.2.0/inklecate_linux.zip
-          echo "v1.2.0" > inklecate_version.txt
       - name: Unzip inklecate
-        run: unzip -o inklecate_linux.zip
+        run: unzip -o inklecate_linux.zip inklecate/
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pexpect 
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.txt
       - name: Run tests
         run: |
           pytest -s tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+inklecate/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pexpect==4.9.0
+pytest==7.4.4

--- a/story.ink
+++ b/story.ink
@@ -12,7 +12,7 @@ VAR has_documents = false
 Subject: Agent Raven
 Preamble: Intel has confirmed that "Drone Dynamics" is currently processing an order to manufacture a new swarm of killer drones for a terrorist organisation. This mission is critical: we must obtain a drone prototype and uncover the identity of the client.
 
-Mission: Infiltrate the "Drone Dynamics" manufacturing facility. Your objectives are to steal a physical drone prototype and retrieve order and shipping documents. Our organization has successfully hacked the building's security systems, allowing for a brief window where alarms and cameras will be disabled.
+Mission: Infiltrate the "Drone Dynamics" manufacturing facility. Your objectives are to steal a physical drone prototype and retrieve order and shipping documents. Our organization has successfully hacked the building's security systems, allowing for a brief window where alarms and cameras will be disabled...
 
 Agent Raven has two options for entry:
 

--- a/tests/test_clock_redirection.py
+++ b/tests/test_clock_redirection.py
@@ -7,7 +7,7 @@ def p():
     Run inklecate and yield the pexpect spawn object.
     This gets executed before each test function and is passed as the `p` argument.
     """
-    child = pexpect.spawn('./inklecate -k -p story.ink', encoding='utf-8', timeout=5)
+    child = pexpect.spawn('./inklecate/inklecate -k -p story.ink', encoding='utf-8', timeout=5)
     # child.logfile_read = sys.stdout  # Redirect output to stdout for debugging
     yield child
     child.terminate(force=True)

--- a/tests/test_endings.py
+++ b/tests/test_endings.py
@@ -7,7 +7,7 @@ def p():
     Run inklecate and yield the pexpect spawn object.
     This gets executed before each test function and is passed as the `p` argument.
     """
-    child = pexpect.spawn('./inklecate -k -p story.ink', encoding='utf-8', timeout=5)
+    child = pexpect.spawn('./inklecate/inklecate -k -p story.ink', encoding='utf-8', timeout=5)
     # child.logfile_read = sys.stdout  # Redirect output to stdout for debugging
     yield child
     child.terminate(force=True)


### PR DESCRIPTION
Introducing requirements.txt so python dependencies are fixed.
One day it can be dockerized.
Downloading inklecate to a standalone directory (gitignored), so one day local workflows with inklecate can be introduced.